### PR TITLE
Updated useDrizzleState to use deepEqual instead of shallowEqual

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1107,6 +1107,11 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+    },
     "define-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
@@ -3689,11 +3694,6 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
-    },
-    "shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
   "license": "ISC",
   "dependencies": {
     "debounce": "^1.2.0",
+    "deep-equal": "^1.0.1",
     "prop-types": "^15.6.2",
-    "react": "^16.4.2",
-    "shallowequal": "^1.1.0"
+    "react": "^16.4.2"
   },
   "devDependencies": {
     "babel-core": "^6.26.3",

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -11,7 +11,7 @@ import createUseCacheCall from './create-use-cache-call'
 import createUseCacheEvents from './create-use-cache-events'
 import createUseCacheSend from './create-use-cache-send'
 import debounce from 'debounce'
-import shallowequal from 'shallowequal'
+import deepEqual from 'deep-equal'
 
 const Context = createContext()
 export const useDrizzle = () => useContext(Context)
@@ -35,10 +35,10 @@ export const useDrizzleState = (mapState, args) => {
     mapStateRef.current(drizzle.store.getState())
   )
   const stateRef = useRef(state)
-  if (!shallowequal(argsRef.current, args)) {
+  if (!deepEqual(argsRef.current, args)) {
     argsRef.current = args
     const newState = mapStateRef.current(drizzle.store.getState())
-    if (!shallowequal(stateRef.current, newState)) {
+    if (!deepEqual(stateRef.current, newState)) {
       stateRef.current = newState
       setState(newState)
     }
@@ -48,7 +48,7 @@ export const useDrizzleState = (mapState, args) => {
       // Debounce udpates, because sometimes the store will fire too much when there are a lot of `cacheCall`s and the cache is empty.
       const debouncedHandler = debounce(() => {
         const newState = mapStateRef.current(drizzle.store.getState())
-        if (!shallowequal(stateRef.current, newState)) {
+        if (!deepEqual(stateRef.current, newState)) {
           stateRef.current = newState
           setState(newState)
         }


### PR DESCRIPTION
When useDrizzleState is called with a request to a deep object (such as accounts, accountBalances), the equality comparison would always return false, resulting in infinite renders of calling components.

Comparing with deepEqual instead resolves this.